### PR TITLE
fix: guard Supabase usage when env vars are missing

### DIFF
--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -1,6 +1,13 @@
-import { createClient } from '@supabase/supabase-js'
+import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey)
+if (!supabaseUrl || !supabaseAnonKey) {
+  console.warn(
+    'Supabase environment variables are missing. Supabase-backed features will be disabled.',
+  );
+}
+
+export const supabase =
+  supabaseUrl && supabaseAnonKey ? createClient(supabaseUrl, supabaseAnonKey) : null;

--- a/server/get-notion-categories.ts
+++ b/server/get-notion-categories.ts
@@ -9,6 +9,10 @@ type NotionCategory = {
 };
 
 const getNotionCategoriesUncached = async (): Promise<NotionCategory[]> => {
+  if (!supabase) {
+    return [];
+  }
+
   try {
     const { data, error } = await supabase
       .from('notion_categories')

--- a/server/get-notion-pages-by-category.ts
+++ b/server/get-notion-pages-by-category.ts
@@ -11,7 +11,7 @@ export const handleNotionPagesByCategory = async (
   page = 1,
   pageSize = 12,
 ): Promise<NotionPagesByCategoryResult> => {
-  if (!category.trim()) return { data: [], total: 0 };
+  if (!category.trim() || !supabase) return { data: [], total: 0 };
   try {
     const from = (page - 1) * pageSize;
     const to = from + pageSize - 1;

--- a/server/get-notion-pages-by-search.ts
+++ b/server/get-notion-pages-by-search.ts
@@ -11,7 +11,7 @@ export const getSearchedNotionPages = async (
   page = 1,
   pageSize = 12,
 ): Promise<SearchNotionPagesResult> => {
-  if (!keyword) return { data: [], total: 0 };
+  if (!keyword || !supabase) return { data: [], total: 0 };
   try {
     const from = (page - 1) * pageSize;
     const to = from + pageSize - 1;

--- a/server/get-notion-pages.ts
+++ b/server/get-notion-pages.ts
@@ -13,6 +13,10 @@ const getNotionPagesUncached = async (
   page = 1,
   pageSize = 12,
 ): Promise<NotionPagesResult> => {
+  if (!supabase) {
+    return { data: [], total: 0 };
+  }
+
   try {
     const from = (page - 1) * pageSize;
     const to = from + pageSize - 1;

--- a/server/increase-notion-view.ts
+++ b/server/increase-notion-view.ts
@@ -1,7 +1,7 @@
 import { supabase } from '@/lib/supabaseClient';
 
 export async function increaseNotionView(pageId: string): Promise<boolean> {
-  if (!pageId || typeof pageId !== 'string') {
+  if (!pageId || typeof pageId !== 'string' || !supabase) {
     return false;
   }
 


### PR DESCRIPTION
### Motivation
- Prevent page load failures when `NEXT_PUBLIC_SUPABASE_URL` or `NEXT_PUBLIC_SUPABASE_ANON_KEY` are not set, because client creation previously used non-null assertions at import time and could throw. 
- Fail closed for Supabase-backed features so the site remains accessible in environments without Supabase configuration.

### Description
- Make `lib/supabaseClient.ts` create the Supabase client only when both env vars are present, log a warning when they are missing, and export `supabase` as `null` otherwise. 
- Add a null-client guard to `server/increase-notion-view.ts` so view increments are skipped when `supabase` is not available. 
- Add null-client guards to `server/get-notion-pages.ts`, `server/get-notion-pages-by-category.ts`, `server/get-notion-pages-by-search.ts`, and `server/get-notion-categories.ts` so they return safe empty results when `supabase` is `null`.

### Testing
- Ran `yarn test:lint`, which failed in this environment because ESLint cannot load `@fisch0920/config` (missing dependency), so linting could not complete. 
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e19ade315c83258fcae0883bedc281)